### PR TITLE
deleting notes that are not longer relevant

### DIFF
--- a/chapters/02_pandas-basics.md
+++ b/chapters/02_pandas-basics.md
@@ -543,22 +543,6 @@ arrays of strings. In that case, you can generally assume all of the elements
 are type `str`. If you're ever unsure of the type of an element, you can always
 use `type` to check.
 
-:::{note}
-NumPy doesn't have a dedicated string type because the way strings are stored
-in memory is very different from the way numbers are stored. Since Pandas is
-based on NumPy, until recently Pandas didn't have a dedicated string type
-either. So both use `object` as the element type for Series and arrays of
-strings.
-
-As of Pandas 1.0, the developers have added an [experimental `string`
-type][pd-string] so that users can distinguish Series of strings from Series of
-mixed types. Hopefully in the future the `string` type will become the main way
-to handle strings rather than an experimental feature.
-
-[pd-string]: https://pandas.pydata.org/pandas-docs/stable/user_guide/text.html
-:::
-
-
 (coercion-conversion)=
 ### Coercion & Conversion
 

--- a/chapters/03_exploring-data.md
+++ b/chapters/03_exploring-data.md
@@ -350,24 +350,6 @@ Before building a visualization, you will need to do a few preparatory steps.
 (install-import-plotnine)=
 ### Install and Import plotnine
 
-:::{note}
-As of writing, conda installs plotnine 0.9 and matplotlib 3.6.1 by default.
-This is a problem, because plotnine 0.9 is incompatible with matplotilb >= 3.6.
-
-Incompatibility between different versions of packages is common and exactly
-what conda was designed to solve. In this case, you can simply make sure that
-you have a slightly older version of matplotlib by running this command in the
-Terminal:
-
-```
-conda install -c conda-forge 'matplotlib<3.6'
-```
-
-The plotnine developers have already fixed the problem in the newest version of
-plotnine, so once it's available through conda, this workaround will no longer
-be necessary.
-:::
-
 While Matplotlib is included with Anaconda, plotnine is not. You will need to
 install the plotnine package in order to use it. {numref}`installing-packages`
 showed you how to install packages with conda via the Terminal:


### PR DESCRIPTION
One note from 3.5.1 on matplotlib incompatability and one from 2.3.1 on the "experimental" string dtype. #6